### PR TITLE
Improve loadless, add autostart and m20 boss split

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 ## Features
 
+- Automatically start the timer when selecting Mission Start on Prologue or Mission 01
 - Automatically pause timer during loading screens (Game Time timing method)
 - Automatically split post-mission during the glass crack
+- Automatically split on defeating Mission 20 boss
 
 ## Livesplit Configuration
 
@@ -19,13 +21,14 @@
 Example Livesplit Layout: [dmc5_ll_splits.lsl](dmc5_ll_splits.lsl)
 
 ## TO-DO
-- Automatically start the timer when selecting Mission Start on Prologue or Mission 01
-- Automatically split when boss HP bar hits zero during Mission 20
+
 - Automatically split for sealed fights
 - Detect loading for in-mission cutscenes
 
 ## Known Issues
-- Beginning of some missions is treated as loading until the HUD is displayed
+
+- Inconsistent auto-start behavior
+- Checkpoint/Retry/Quit Mission loading timer pause is delayed
 
 ## Contact
 

--- a/dmc5.asl
+++ b/dmc5.asl
@@ -1,7 +1,27 @@
+/*
+    Devil May Cry 5 Autosplitter and Loadless Timer
+    Version: 0.2
+    Author: remote_mine
+    Compatible Versions: Steam
+
+    Thanks to Tektheist for ideas and help with testing!
+*/
+
 state("DevilMayCry5", "1.07")
 {
     byte missionNumber : 0x07A9A2E0, 0x88;
-    byte isLoading : 0x07B53A58, 0x8; // 0 for loading. some cutscenes, black screens and pre-mission stuff have a zero value as well
+    byte gameState : 0x07B53A58, 0x8;
+
+    int playerLoaded : 0x07A6E5C8, 0x140, 0x1F8, 0x200, 0x80, 0x20;
+
+    int finalBossPointer : 0x07A72E58, 0x140, 0x250, 0x28, 0x88;
+    float finalBossHP : 0x07A72E58, 0x140, 0x250, 0x28, 0x88, 0x10;
+}
+
+startup
+{
+    vars.isLoading = false;
+    vars.gameWasPaused = false;
 }
 
 init
@@ -17,19 +37,64 @@ init
     if (version != "1.07")
     {
         MessageBox.Show(timer.Form,
-            "Error: only supported version of DMC5 is 1.07",
-            "Warning",
+            "Warning: Could not determine DMC5 version.\nOnly Steam version 1.07 is currently supported",
+            "LiveSplit: Unknown Game Version",
             MessageBoxButtons.OK,
             MessageBoxIcon.Warning);
     }
 }
 
+update
+{
+    /*
+        gameState is 0 for most loading (plus a few edge cases)
+        gameState is 9 for pause menu screen
+
+        This fixes in-mission intro "loading" (gameState is 0 until HUD shows)
+        Special case to check for pause menu during pre-HUD "loading"
+    */
+    if (current.gameState != old.gameState)
+    {
+        vars.gameWasPaused = old.gameState == 9;
+        vars.isLoading = (current.gameState == 0 && !vars.gameWasPaused);
+    }
+
+    if (current.playerLoaded != old.playerLoaded)
+    {
+        if (current.playerLoaded > 0)
+        {
+            vars.isLoading = false;
+        }
+        else if (current.gameState == 0 && vars.gameWasPaused)
+        {
+            // load screen after pausing (checkpoint/retry/quit mission)
+            vars.isLoading = true;
+        }
+    }
+}
+
+start
+{
+    if (current.missionNumber == 0 || current.missionNumber == 1)
+    {
+        return current.playerLoaded != old.playerLoaded && current.playerLoaded > 0;
+    }
+}
+
 split
 {
-    return current.missionNumber == old.missionNumber + 1;
+    if (current.missionNumber == 20 && current.finalBossPointer > 0 && old.finalBossHP > 0)
+    {
+        return current.finalBossHP == 0;
+    }
+
+    if (current.missionNumber != old.missionNumber)
+    {
+        return current.missionNumber == old.missionNumber + 1;
+    }
 }
 
 isLoading
 {
-    return current.isLoading == 0;
+    return vars.isLoading;
 }


### PR DESCRIPTION
* Fix issue with game timer staying paused even after mission has started
* Add Prologue/M1 autostart - known issue with not always starting on some systems
* Add autosplit on defeating M20 boss instead of post-cutscene